### PR TITLE
Add page dialog

### DIFF
--- a/blocks/site-details/site-details.css
+++ b/blocks/site-details/site-details.css
@@ -342,6 +342,13 @@
     font-size: 11px;
 }
 
+/* MARK: add page */
+
+.site-details.block .add-page-container {
+    display: flex;
+    justify-content: flex-end;
+}
+
 
 /* MARK: description dialog */
 

--- a/blocks/site-details/site-details.css
+++ b/blocks/site-details/site-details.css
@@ -349,7 +349,6 @@
     justify-content: flex-end;
 }
 
-
 /* MARK: description dialog */
 
 dialog.update-description-dialog form {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -405,8 +405,8 @@ dialog .dialog-button-container > * {
   align-items: flex-start;
 }
 
-dialog .dialog-content:has(.centered-info) {
-  min-height: auto;
+dialog .template-preview {
+  border: none;
 }
 
 dialog .dialog-content > div:has(> .centered-info),


### PR DESCRIPTION
Add page button above page list in site settings. Opens dialog to choose an example page template. Options come from sidekick library. Entries starting with "template -" but not "template - authoring guide -"(forgiving regex) can be selected.
