### PR TITLE
Updates & revert functionality

### DIFF
--- a/blocks/site-details/site-details.js
+++ b/blocks/site-details/site-details.js
@@ -613,7 +613,7 @@ async function renderUpdatesSection(div, { project, headers }) {
   if (versionInfo.updateAvailable) {
     div.innerHTML = `
       <h3>A new version is available!</h3>
-      ${versionInfo.updateLevel === 'major' ? '<p><strong><span>This version is a major update. It is possible some blocks need to be updated.</span></strong></p>' : ''}
+      ${versionInfo.updateLevel === 'major' ? '<p><strong><span>This version is a major update. It is possible some blocks will need to be updated by authors.</span></strong></p>' : ''}
     `;
 
     const updateButton = document.createElement('button');
@@ -621,7 +621,12 @@ async function renderUpdatesSection(div, { project, headers }) {
     updateButton.innerText = 'Update';
     updateButton.onclick = async () => {
       const dialogContent = document.createElement('div');
-      dialogContent.innerHTML = '<h3>Update Project</h3><p>Are you sure you want to update this project? This will take a short while.</p><p>This action can be undone, but changes to icons, blocks, and site theme made after an update, will also be reverted when undone.</p>';
+      dialogContent.innerHTML = `
+        <h3>Update Project</h3>
+        <p>Are you sure you want to update this project? This will take a short while.</p>
+        ${versionInfo.updateLevel === 'major' ? '<p class="warning"><strong>This is a major update! It is possible some blocks will need to be updated by authors.</strong></p>' : ''}
+        <p>This action can be undone, but changes to icons, blocks, and site theme made after an update, will also be reverted when undone.</p>
+      `;
       const confirmUpdateButton = document.createElement('button');
       confirmUpdateButton.classList.add('button', 'action', 'secondary', 'update-button');
       confirmUpdateButton.innerText = 'Update';
@@ -673,7 +678,7 @@ async function renderPrevUpdatesSection(div, {
   prevUpdatesButton.innerText = 'Revert to previous version';
   prevUpdatesButton.onclick = async () => {
     const dialogContent = document.createElement('div');
-    dialogContent.innerHTML = '<h3>Revert Project</h3><h4>Loading previous updates...</h4>';
+    dialogContent.innerHTML = '<h3>Revert Project</h3><h4 class="centered-info">Loading previous updates...</h4>';
     const revertUpdateDialog = window.createDialog(dialogContent, []);
 
     const updateList = await fetch(`${endpoint}appliedUpdates/${project.projectSlug}`, { headers }).then((res) => res.json()).catch(() => null);
@@ -726,9 +731,8 @@ async function renderPrevUpdatesSection(div, {
           });
           if (revertUpdateResponse.ok) {
             revertUpdateDialog.renderDialog('<h3 class="centered-info">Project reverted successfully!</h3>');
-            // replace update button/up-to-date message, check for updates after 6sec
-            updateInfoDiv.innerHTML = '<h3>Project reverted successfully!</h3>';
-            setTimeout(() => rerenderUpdatesSection(updateInfoDiv, { project, headers }), 15000);
+            // rerender update section. Should say an update is available as one has just been reverted
+            rerenderUpdatesSection(updateInfoDiv, { project, headers });
           } else {
             revertUpdateDialog.renderDialog(OOPS);
           }
@@ -736,9 +740,9 @@ async function renderPrevUpdatesSection(div, {
         }
       };
     } else if (updateList.length === 0) {
-      dialogContent.innerHTML = '<h3>Revert Project</h3><h4>No updates to revert to.</h4>';
+      dialogContent.innerHTML = '<h3>Revert Project</h3><h4 class="centered-info">No updates to revert to.</h4>';
     } else {
-      dialogContent.innerHTML = '<h3>Revert Project</h3><h4>Could not get update information.</h4>';
+      dialogContent.innerHTML = '<h3>Revert Project</h3><h4 class="centered-info">Could not get update information.</h4>';
     }
   };
   div.append(prevUpdatesButton);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -110,11 +110,6 @@ p {
   line-height: 22px;
 }
 
-p.warning,
-p.warning *{
-  color: var(--orange);
-}
-
 ul,
 ol {
   margin-block: 16px;
@@ -483,8 +478,16 @@ dialog .dialog-content > div:has(> .centered-info),
 dialog .centered-info {
   display: flex;
   flex: 1;
+}
+
+dialog .centered-info {
   align-items: center;
   justify-content: center;
+}
+
+dialog .warning,
+dialog .warning *{
+  color: var(--orange);
 }
 
 @media (width < 768px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -110,6 +110,11 @@ p {
   line-height: 22px;
 }
 
+p.warning,
+p.warning *{
+  color: var(--orange);
+}
+
 ul,
 ol {
   margin-block: 16px;
@@ -514,6 +519,25 @@ dialog.alert-dialog .dialog-content {
 ::backdrop {
   background: rgba(0 0 0 / 20%);
   backdrop-filter: blur(2px);
+}
+
+
+/* MARK: prev updates */
+
+dialog #revert-form ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+dialog #revert-form label {
+  display: flex;
+  gap: 20px;
+  justify-content: flex-start;
+}
+
+dialog #revert-form label input{
+  flex: 0;
 }
 
 


### PR DESCRIPTION
**Requires `templateInfo.json` to root of both template & project**

Settings tab of site-details page checks templateInfo of project & template to see if a higher version is avalible.

User can choose to update, extra text in the dialog will inform the user if it is a major update that can potentially break block authoring.

Users can revert to last commit before update in the revert dialog. This undoes changes made in the blocks, icons & theme editors.


Test URLs:

Before: https://main--eds-self-service-website--headwire-edge-delivery.hlx.live/
After: https://updates--eds-self-service-website--headwire-edge-delivery.hlx.live/
