### PR TITLE
Web Analytics Update

### DIFF
--- a/blocks/site-details/site-details.css
+++ b/blocks/site-details/site-details.css
@@ -129,6 +129,18 @@
     padding-block: 8px;
 }
 
+.site-details.block .title {
+    margin-top: 16px;
+    padding-bottom: 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.site-details.block .title h2 {
+    padding: 0;
+}
+
 .site-details.block .container {
     width: 100%;
     overflow: auto;
@@ -168,7 +180,15 @@
     text-align: center;
     word-wrap: break-word;
 }
-    
+
+.site-details.block .cards .cwp-box ul {
+    list-style: none;
+    padding: 0 !important;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
 .site-details.block .cards .box p {
     display: flex;
     justify-content: space-between;

--- a/blocks/site-details/site-details.js
+++ b/blocks/site-details/site-details.js
@@ -2206,15 +2206,16 @@ export default async function decorate(block) {
       const period = block.querySelector('.period-selector');
 
       const renderWebAnalytics = ([metrics, cww]) => {
-        const totalVisits = metrics[0].data.viewer.accounts[0]?.total[0]?.sum?.visits ?? 0;
-        const totalPageViews = metrics[0].data.viewer.accounts[0]?.total[0]?.count ?? 0;
-        const medianPageLoadTime = metrics[2].data.viewer.accounts[0]?.totalPerformance[0]?.aggregation?.pageLoadTime ?? 0;
+        const totalVisits = metrics[0]?.data?.viewer.accounts[0]?.total[0]?.sum?.visits ?? 0;
+        const totalPageViews = metrics[0]?.data?.viewer.accounts[0]?.total[0]?.count ?? 0;
+        const medianPageLoadTime = metrics[2]?.data?.viewer.accounts[0]?.totalPerformance[0]?.aggregation?.pageLoadTime ?? 0;
 
-        const visitsDelta = metrics[2].data.viewer.accounts[0].visitsDelta[0] ? ((totalVisits * 100) / metrics[2].data.viewer.accounts[0].visitsDelta[0].sum.visits) - 100 : 0;
-        const pageViewsDelta = metrics[2].data.viewer.accounts[0].pageviewsDelta[0] ? ((totalPageViews * 100) / metrics[2].data.viewer.accounts[0].pageviewsDelta[0].count) - 100 : 0;
-        const performanceDelta = metrics[2].data.viewer.accounts[0].performanceDelta[0] ? ((medianPageLoadTime * 100) / metrics[2].data.viewer.accounts[0].performanceDelta[0].aggregation.pageLoadTime) - 100 : 0;
+        const visitsDelta = metrics[2]?.data?.viewer.accounts[0].visitsDelta[0] ? ((totalVisits * 100) / metrics[2].data.viewer.accounts[0].visitsDelta[0].sum.visits) - 100 : 0;
+        const pageViewsDelta = metrics[2]?.data?.viewer.accounts[0].pageviewsDelta[0] ? ((totalPageViews * 100) / metrics[2].data.viewer.accounts[0].pageviewsDelta[0].count) - 100 : 0;
+        const performanceDelta = metrics[2]?.data?.viewer.accounts[0].performanceDelta[0] ? ((medianPageLoadTime * 100) / metrics[2].data.viewer.accounts[0].performanceDelta[0].aggregation.pageLoadTime) - 100 : 0;
 
         container.innerHTML = `
+        <div class="title"><h2>Last ${period.value === '1d' ? '24 Hours' : period.value.replace('d', ' Days')}</h2>${period.value === '30d' ? '<i>(Based on a 10% sample of page load events)</i>' : ''}</div>
           <div class="cards">
             <div id="total-visits" class="box">
                 <strong>Total visits</strong>
@@ -2249,7 +2250,7 @@ export default async function decorate(block) {
                 </div>
                 <div id="visits-details-referers" class="box">
                     <strong>By referers</strong>
-                    ${metrics[0].data.viewer.accounts[0].topReferers.map((referer) => `
+                    ${metrics[0].data.viewer.accounts[0].topReferers.filter((ref) => ref.sum.visits > 1).map((referer) => `
                       <p><span title="${referer.dimensions.metric ? referer.dimensions.metric : 'None (direct)'}">${referer.dimensions.metric ? referer.dimensions.metric : 'None (direct)'}</span><span>${referer.sum.visits}</span></p>
                     `).join('')}
                 </div>


### PR DESCRIPTION
- Added a h2 which shows for how many days the analytics is shown with a note for 30 days, that it is _"Based on a 10% sample of page load events"_:

![image](https://github.com/user-attachments/assets/48328b2f-4a3b-4888-bdec-f78e2a7f852a)

- "Visits details > By referers" would sometimes show the page itself as a referer but with 0 hits. So 0 hits are filtered out.
- "By Path and Browsers" CSS Fix

Test URLs:
- Before: https://main--eds-self-service-website--headwire-edge-delivery.hlx.live/
- After: https://webanalytics--eds-self-service-website--headwire-edge-delivery.hlx.live/
