### PR TITLE
Template sheet

### DIFF
--- a/.github/workflows/refreshTemplateList.yaml
+++ b/.github/workflows/refreshTemplateList.yaml
@@ -2,14 +2,13 @@ on:
   repository_dispatch:
     types:
       - resource-published
+    if: github.event.client_payload.status == '200' && github.event.client_payload.path == '/templates.json'
 jobs:
-  print:
+  Refresh template list on server:
     runs-on: ubuntu-latest
     steps:
     - run: |
         echo "Status: ${{ github.event.client_payload.status }}"
         echo "Path: ${{ github.event.client_payload.path }}"
     - run: |
-        if [ "${{ github.event.client_payload.status }}" = "200" ] && [ "${{ github.event.client_payload.path }}" = "/templates.json" ]; then
-          curl -X GET "https://api.kestrelone.com/refreshTemplates"
-        fi
+        curl -X GET "https://api.kestrelone.com/refreshTemplates"

--- a/.github/workflows/refreshTemplateList.yaml
+++ b/.github/workflows/refreshTemplateList.yaml
@@ -1,0 +1,15 @@
+on: 
+  repository_dispatch:
+    types:
+      - resource-published
+jobs:
+  print:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo "Status: ${{ github.event.client_payload.status }}"
+        echo "Path: ${{ github.event.client_payload.path }}"
+    - run: |
+        if [ "${{ github.event.client_payload.status }}" = "200" ] && [ "${{ github.event.client_payload.path }}" = "/templates.json" ]; then
+          curl -X GET "https://api.kestrelone.com/refreshTemplates"
+        fi

--- a/blocks/wizard/wizard.js
+++ b/blocks/wizard/wizard.js
@@ -93,7 +93,7 @@ export default async function decorate(block) {
   });
 
   // TODO replace templates json with endpoint ?
-  const templates = block.querySelector('a[href="/templates.json"]');
+  const templates = block.querySelector(`a[href="/templates.json"], a[href="${SCRIPT_API}/templates"]`);
   if (templates) {
     const templateWrapper = document.createElement('div');
     templateWrapper.className = 'template-wrapper';
@@ -148,7 +148,7 @@ export default async function decorate(block) {
 
     templates.parentElement.replaceWith(templateWrapper);
 
-    fetch(templates.href)
+    fetch(`${SCRIPT_API}/templates`)
       .then((req) => req.json())
       .then(({ data }) => {
         const render = () => {


### PR DESCRIPTION
Getting template list from backend, so they are always in-sync.

Backend now gets template list from the `templates.json` sheet on startup. Is refreshed through an endpoint called with the on-publish action.
