### PR TITLE
remove checklist visibility refresh listener if unloaded

### DIFF
--- a/blocks/site-details/renderCheckList.js
+++ b/blocks/site-details/renderCheckList.js
@@ -280,21 +280,19 @@ export default async function renderCheckList({
     renderChecklistItems(fetchedChecklistData);
   };
 
-  // list reloads
+  // refetch if loaded after another tab
   if (historyArray.length > 1) {
     reloadChecklist();
   }
 
-  document.addEventListener('visibilitychange', () => {
+  const visibilityHandler = () => {
+    if (!document.body.contains(container)) {
+      // remove self if container was removed (other tab opened)
+      document.removeEventListener('visibilitychange', visibilityHandler);
+      return;
+    }
     if (document.hidden) return;
     reloadChecklist();
-  });
-
-  // currently disabled until we have abortcontroller / clearinstervals
-  // setInterval(() => {
-  //   if (cooldown) return;
-  //   reloadChecklist();
-  // }, 30000);
-
-  // TODO: checklist triggers
+  };
+  document.addEventListener('visibilitychange', visibilityHandler);
 }


### PR DESCRIPTION
Fix #159 

Checklist listener persisted when switching tabs. This caused requests on visibility change even when checklist was no longer loaded and created multiple listeners if opening overview multiple times.

Listener is now destroyed if container element is no longer in the dom.

Also removed some commented code, which we likely won't re-use. And updated a comment to better understand why we refresh based on history length.
