### PR TITLE
Reworked skeleton animation so it won't cause unexpected scrollbars

### DIFF
--- a/scripts/dialogs.js
+++ b/scripts/dialogs.js
@@ -52,10 +52,8 @@ export const createDialog = (contentDiv, buttons, {
   dialog.setLoading = (toggleOn = true, customLoadingText = 'Loading…') => {
     if (toggleOn) {
       dialog.classList.add('loading');
-      dialogContent.classList.add('skeleton');
     } else {
       dialog.classList.remove('loading');
-      dialogContent.classList.remove('skeleton');
     }
     dialog.dataset.loadingText = customLoadingText;
   };

--- a/styles/dialogs.css
+++ b/styles/dialogs.css
@@ -106,8 +106,13 @@ dialog.loading::before {
     overflow: hidden;
 }
 
-dialog.loading .skeleton {
-    opacity: .5;
+dialog.loading .dialog-content {
+    background: var(--skeleton-bg);
+    animation: skeleton-bg-slide 1s ease-in-out infinite;
+}
+
+dialog.loading .dialog-content > * {
+    opacity: 0.25;
 }
 
 dialog .dialog-content .dialog-button-container {

--- a/styles/skeletons.css
+++ b/styles/skeletons.css
@@ -15,6 +15,7 @@ div[aria-label="loading"] > table > tbody > tr > td {
     0% {
         background-position: 100% 0;
     }
+    
     100% {
         background-position: -100% 0;
     }

--- a/styles/skeletons.css
+++ b/styles/skeletons.css
@@ -6,32 +6,19 @@ div[aria-label="loading"] > table > tbody > tr > td {
 .skeleton {
     position: relative;
     overflow: hidden;
-    background-color: var(--light-gray);
+    background: var(--skeleton-bg);
     border-radius: var(--small-border-radius);
+    animation: skeleton-bg-slide 1s ease-in-out infinite;
 }
 
-.skeleton::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
-    width: 100%;
-    background: linear-gradient(90deg, transparent, rgba(0 0 0 / 5%), transparent);
-    transform: translateX(-100%);
-    animation: skeleton-slide 1s ease-in-out infinite;
-}
-
-@keyframes skeleton-slide {
+@keyframes skeleton-bg-slide {
     0% {
-        transform: translateX(-100%);
+        background-position: 100% 0;
     }
-
     100% {
-        transform: translateX(100%);
+        background-position: -100% 0;
     }
 }
-
 
 .skeleton-theme-editor-iframe {
     width: 810px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -25,6 +25,10 @@
   --border-radius: 15px;
   --small-border-radius: 8px;
 
+  --skeleton-bg-light: var(--light-gray);
+  --skeleton-bg-dark: #e2e2e2;
+  --skeleton-bg: linear-gradient(90deg, var(--skeleton-bg-light) 0%, var(--skeleton-bg-dark) 25%, var(--skeleton-bg-light) 50%) 100% 0 / 200% 100%;
+
   font-synthesis: none;
   text-rendering: optimizelegibility;
   -webkit-font-smoothing: antialiased;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -24,7 +24,6 @@
   --icon-drop-shadow: drop-shadow(0 0 1px var(--black));
   --border-radius: 15px;
   --small-border-radius: 8px;
-
   --skeleton-bg-light: var(--light-gray);
   --skeleton-bg-dark: #e2e2e2;
   --skeleton-bg: linear-gradient(90deg, var(--skeleton-bg-light) 0%, var(--skeleton-bg-dark) 25%, var(--skeleton-bg-light) 50%) 100% 0 / 200% 100%;


### PR DESCRIPTION
Skeleton animation was causing scrollbars on dialogs and in other places if overflow was not set to hidden, which was often required on elements.

New animation using background position. Looks identical everywhere except dialog. Dialog loading is slightly different from before because of the opacity it uses, but it's still very similar
