### PR TITLE
optimized SEO tab

### DIFF
--- a/blocks/site-details/renderSiteSEO.js
+++ b/blocks/site-details/renderSiteSEO.js
@@ -50,7 +50,7 @@ export default async function renderSiteSEO({ container, nav, renderOptions }) {
     nav.querySelector('button.bulk-metadata').onclick = async (event) => {
       const button = event.target;
       button.classList.add('loading');
-      const statusData = await fetch(`https://admin.hlx.page/status/${projectRepo}/${siteSlug}/main/metadata.json?editUrl=auto`).then((res) => res.json()).catch(() => null);
+      const statusData = await fetch(`https://admin.hlx.page/status/${projectRepo}/${siteSlug}/${defaultBranch}/metadata.json?editUrl=auto`).then((res) => res.json()).catch(() => null);
       if (statusData?.edit?.url) {
         window.open(statusData.edit.url, '_blank');
       } else {

--- a/scripts/toast.js
+++ b/scripts/toast.js
@@ -52,6 +52,6 @@ export function showToast(text = 'Done.', type = 'success') {
   }, delay);
 }
 
-export function showErrorToast() {
-  showToast(OOPS, 'error');
+export function showErrorToast(content = OOPS) {
+  showToast(content, 'error');
 }


### PR DESCRIPTION
The previous version of the SEO tab would fetch the index, sort through pages and then fetch each one to extract the metadata.
This took a while and was doing stuff the EDS indexing system already does.

I recently updated `helix-query.yaml` in the templates so we only index relevant pages, now we can use query-index instead. Reducing the amount of requests made.

Fix #211 
