### PR TITLE
Action sheet fix

### DIFF
--- a/blocks/site-details/renderSiteSpreadsheets.js
+++ b/blocks/site-details/renderSiteSpreadsheets.js
@@ -97,7 +97,6 @@ export default async function renderSiteSpreadsheets({ container, renderOptions 
     const discardButton = container.querySelector('#discard-changes');
 
     const setButtonText = () => {
-      console.log('\x1b[34m ~ setButtonText:');
       const table = container.querySelector('.sheet');
       const currentMode = table.getAttribute('data-editMode');
       const editButton = container.querySelector('#edit-sheet');
@@ -192,11 +191,6 @@ export default async function renderSiteSpreadsheets({ container, renderOptions 
         newPreviewButton.disabled = false;
         tabsAside.dataset.unsavedChanges = 'false';
       }
-      console.log(' editButton.textContent:', editButton.textContent);
-      console.log(' discardButton.hidden:', discardButton.hidden);
-      console.log(' newPublishButton.disabled:', newPublishButton.disabled);
-      console.log(' newPreviewButton.disabled:', newPreviewButton.disabled);
-      console.log(' tabsAside.dataset.unsavedChanges:', tabsAside.dataset.unsavedChanges);
       previewAndPublishButtons();
     };
 

--- a/blocks/site-details/renderSiteSpreadsheets.js
+++ b/blocks/site-details/renderSiteSpreadsheets.js
@@ -1,7 +1,9 @@
 import {
   OOPS,
   SCRIPT_API,
+  defaultBranch,
   parseFragment,
+  projectRepo,
   safeText,
 } from '../../scripts/scripts.js';
 import renderSkeleton from '../../scripts/skeletons.js';
@@ -63,6 +65,7 @@ export default async function renderSiteSpreadsheets({ container, renderOptions 
   let contentChanged = () => false;
 
   const fetchAndRenderSheet = async (selected) => {
+    container.inert = true;
     selectedSheet = selected;
     sheetID = selectedSheet.id;
     sheetName = selectedSheet.name;
@@ -94,6 +97,7 @@ export default async function renderSiteSpreadsheets({ container, renderOptions 
     const discardButton = container.querySelector('#discard-changes');
 
     const setButtonText = () => {
+      console.log('\x1b[34m ~ setButtonText:');
       const table = container.querySelector('.sheet');
       const currentMode = table.getAttribute('data-editMode');
       const editButton = container.querySelector('#edit-sheet');
@@ -107,11 +111,9 @@ export default async function renderSiteSpreadsheets({ container, renderOptions 
       const newPublishButton = container.querySelector('#publish-sheet');
       newPublishButton.innerHTML = 'Publish';
       const previewAndPublishButtons = async () => {
-        const org = 'headwire-self-service';
         const site = siteSlug;
-        const ref = 'main';
         const { path } = selectedSheet;
-        const publishPreviewURL = `https://admin.hlx.page/preview/${org}/${site}/${ref}${path}.json`;
+        const publishPreviewURL = `https://admin.hlx.page/preview/${projectRepo}/${site}/${defaultBranch}${path}.json`;
         // eslint-disable-next-line consistent-return
         const post = async (previewOrPublish = 'Preview', url = publishPreviewURL) => {
           const showButtonLoading = (bool = true) => {
@@ -159,7 +161,7 @@ export default async function renderSiteSpreadsheets({ container, renderOptions 
         });
 
         newPublishButton.addEventListener('click', async () => {
-          const publishUrl = `https://admin.hlx.page/live/${org}/${site}/${ref}${path}.json`;
+          const publishUrl = `https://admin.hlx.page/live/${projectRepo}/${site}/${defaultBranch}${path}.json`;
           const previewResponse = await post('PreviewAndPublish');
           if (previewResponse?.ok) {
             await post('Publish', publishUrl);
@@ -190,6 +192,11 @@ export default async function renderSiteSpreadsheets({ container, renderOptions 
         newPreviewButton.disabled = false;
         tabsAside.dataset.unsavedChanges = 'false';
       }
+      console.log(' editButton.textContent:', editButton.textContent);
+      console.log(' discardButton.hidden:', discardButton.hidden);
+      console.log(' newPublishButton.disabled:', newPublishButton.disabled);
+      console.log(' newPreviewButton.disabled:', newPreviewButton.disabled);
+      console.log(' tabsAside.dataset.unsavedChanges:', tabsAside.dataset.unsavedChanges);
       previewAndPublishButtons();
     };
 
@@ -408,6 +415,7 @@ export default async function renderSiteSpreadsheets({ container, renderOptions 
     });
 
     generateSheetTable();
+    container.inert = false;
   };
 
   // Initial render

--- a/blocks/site-details/site-details.css
+++ b/blocks/site-details/site-details.css
@@ -244,6 +244,10 @@
   border-radius: var(--small-border-radius);
 }
 
+.site-details.block .tab-content[inert] {
+  opacity: 0.7;
+}
+
 .site-details.block .tab-content.seo span.previewed,
 .site-details.block .tab-content.seo span.published {
   display: none;

--- a/scripts/dialogs.js
+++ b/scripts/dialogs.js
@@ -1,7 +1,21 @@
 import { loadCSS } from './aem.js';
 
 loadCSS(`${window.hlx.codeBasePath}/styles/dialogs.css`);
-
+/**
+ * Creates a dialog element with specified content and buttons.
+ *
+ * @param {HTMLElement | string} contentDiv - The content to be displayed inside the dialog.
+ * @param {HTMLElement[]} buttons - Array of button elements to be included in the dialog.
+ * Generally button onclicks should be added before createDialog is ran.
+ * If you require the dialog element for them, set options.open to false and run showModal() after.
+ * @param {Object} options - Configuration options for the dialog.
+ * @param {boolean} [options.open=true] - Whether the dialog should be opened immediately.
+ * @param {Function} [options.onCloseFn] - Callback function to be called when the dialog is closed.
+ * @param {boolean} [options.fullscreen] - Whether dialog should be displayed in fullscreen mode.
+ * @param {boolean} [options.surviveClose=false] - Whether dialog element should
+ * exist in DOM after close.
+ * @returns {HTMLDialogElement} The created dialog element.
+ */
 export const createDialog = (contentDiv, buttons, {
   open = true, onCloseFn, fullscreen, surviveClose = false,
 } = {}) => {


### PR DESCRIPTION
Assigning onclicks before showing dialog modal to prevent onclick sometimes not being triggered in test. It wasn't an async function so this shouldn't have been an issue, but somehow it was still happening and after I moved things around it stopped.

Changed document selectors for ones scoped to container, like other blocks.

Setting entire tab-content-container to inert when switching sheets to prevent user input & fixing tests that would click things too early.