### PR TITLE
Extra force-logout

### DIFF
--- a/blocks/wizard/wizard.js
+++ b/blocks/wizard/wizard.js
@@ -94,7 +94,6 @@ export default async function decorate(block) {
     }
   });
 
-  // TODO replace templates json with endpoint ?
   const templates = block.querySelector(`a[href="/templates.json"], a[href="${SCRIPT_API}/templates"]`);
   if (templates) {
     const templateWrapper = document.createElement('div');
@@ -192,6 +191,10 @@ export default async function decorate(block) {
             })
             .join('');
 
+          // This is partly to blame for the create button working while auth0 fails to authenticate.
+          // The extra logout in the catch of auth0.js fixes the issue, so I didn't change anything here, but this setup with two click listeners doing separate things is bad.
+          // Also Somehow this code can be reached sometimes when auth0 fails, resulting in the body not having it's classes. Breaking this half of the listener code.
+          // The later code that routes you to /create will end up doing so without this causing the popup. I still think this entire file should be rewritten
           if (document.body.classList.contains('is-anonymous')) {
             const createLinks = templateContainer.querySelectorAll('a[href$="/create"]');
 

--- a/blocks/wizard/wizard.js
+++ b/blocks/wizard/wizard.js
@@ -193,8 +193,8 @@ export default async function decorate(block) {
 
           // This is partly to blame for the create button working while auth0 fails to authenticate.
           // The extra logout in the catch of auth0.js fixes the issue, so I didn't change anything here, but this setup with two click listeners doing separate things is bad.
-          // Also Somehow this code can be reached sometimes when auth0 fails, resulting in the body not having it's classes. Breaking this half of the listener code.
-          // The later code that routes you to /create will end up doing so without this causing the popup. I still think this entire file should be rewritten
+          // Without the force-logout in auth0.js, somehow this code can be reached sometimes when auth0 fails, resulting in the body not having it's classes (yet?). Breaking this half of the listener code.
+          // The later code that routes you to /create will end up doing so without this listener causing the popup. I still think this entire file should be rewritten
           if (document.body.classList.contains('is-anonymous')) {
             const createLinks = templateContainer.querySelectorAll('a[href$="/create"]');
 

--- a/scripts/auth0.js
+++ b/scripts/auth0.js
@@ -72,6 +72,13 @@ window.auth0
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log(e);
+        // Stephan has an issue where isAuthenticated() returns true, but the above getTokenSilently() fails & was in this catch
+        // Somehow he was still able to go though the wizard to the /create step.
+        // This doesn't make sense since getTokenSilently has to be successful to set the is-authenticated class on body, which is how we check to show the login dialog or continue to /create
+        // I was able to get this to fail earlier in code, by messing with the localStorage in specific ways.
+        // An extra force logout here seems to fix that, hopefully it fixes the issue that can naturally happen as well
+        delete window.localStorage.sessionExpiration;
+        window.auth0Client.logout({ logoutParams: { returnTo: window.location.origin } });
       }
     }
 


### PR DESCRIPTION
Added extra logout in auth0 catch. This fixes an issue where errors in auth0 could allow logged-out users to access `/create`

