### PR TITLE
Redirect fix

### DIFF
--- a/blocks/dashboard/renderAccount.js
+++ b/blocks/dashboard/renderAccount.js
@@ -1,5 +1,6 @@
 import { getUserSettings, OOPS, parseFragment, SCRIPT_API, updateUserSettings, waitForAuthenticated } from '../../scripts/scripts.js';
 import renderSkeleton from '../../scripts/skeletons.js';
+import { createRedirectUrl } from '../../scripts/utils.js';
 
 export default async function renderAccount({ container, nav }) {
   container.insertAdjacentHTML('afterbegin', renderSkeleton('account'));
@@ -51,7 +52,7 @@ export default async function renderAccount({ container, nav }) {
 
   nav.innerHTML = `
     <button id="toggle-auto-tour-button" class="button secondary action">${userSettings?.showAutoTour ? 'Disable Auto Tour' : 'Enable Auto Tour'}</button>
-    <a href="/redirect?url=https://myaccount.google.com/?authuser=${user.email}" target="_blank" id="edit-account-button" class="button edit action primary">Edit account</a>
+    <a href="${createRedirectUrl('https://myaccount.google.com/?authuser=' + user.email)}" target="_blank" id="edit-account-button" class="button edit action primary">Edit account</a>
   `;
 
   const toggleAutoTourButton = document.getElementById('toggle-auto-tour-button');

--- a/blocks/email-composer/email-composer.js
+++ b/blocks/email-composer/email-composer.js
@@ -4,7 +4,7 @@ import { loadCSS, toCamelCase } from '../../scripts/aem.js';
 import { confirmDialog } from '../../scripts/dialogs.js';
 import { showErrorToast, showToast } from '../../scripts/toast.js';
 import { createDialog } from '../../scripts/dialogs.js';
-import { confirmUnsavedChanges } from '../../scripts/utils.js';
+import { confirmUnsavedChanges, createRedirectUrl } from '../../scripts/utils.js';
 
 let timer;
 const debounce = (fn, delay = 800) => {
@@ -262,7 +262,7 @@ export default async function decorate(block) {
           </div>`,
             [
               parseFragment(
-                `<a href="/redirect?url=${project.authoringGuideUrl}" id="guides-button" title="Open the Guide for Mails"
+                `<a href="${createRedirectUrl(project.authoringGuideUrl)}" id="guides-button" title="Open the Guide for Mails"
               class="button action secondary guides" target="_blank">Guides</a>`,
               ),
             ],
@@ -448,7 +448,7 @@ export default async function decorate(block) {
                     <span id="unmet-info" class="info"></span>
                   </div>
 
-            <a href="/redirect?url=${project.authoringGuideUrl}" id="guides-button"
+            <a href="${createRedirectUrl(project.authoringGuideUrl)}" id="guides-button"
             title="Open the Guide for the Template" class="button action secondary guides" target="_blank">Guides</a>
             <a href="${EMAIL_WORKER_API}/preview?contentUrl=${url}" target="_blank" class="button secondary action preview-mail">Preview</a>
             <button id="edit-button" class="button action secondary edit">Edit</button>

--- a/blocks/site-details/renderCampaignsAnalytics.js
+++ b/blocks/site-details/renderCampaignsAnalytics.js
@@ -2,6 +2,7 @@ import { readQueryParams, removeQueryParams, writeQueryParams } from '../../libs
 import { clamp, dateToRelativeSpan, parseFragment, safeText, SCRIPT_API, syntheticClickEvent } from '../../scripts/scripts.js';
 import renderSkeleton from '../../scripts/skeletons.js';
 import { createDialog } from '../../scripts/dialogs.js';
+import { createRedirectUrl } from '../../scripts/utils.js';
 
 const createAnalyticsTableContent = (container, campaignAnalyticsData, search) => {
   if (!campaignAnalyticsData) {
@@ -64,7 +65,7 @@ const createAnalyticsTableContent = (container, campaignAnalyticsData, search) =
 
       return `
         <tr data-email="${emailId}" data-campaign="${campaign}">
-          <td>${emailURL ? `<a href="/redirect?url=${emailURL}" target="_blank">${subject}</a>` : subject}</td>
+          <td>${emailURL ? `<a href="${createRedirectUrl(emailURL)}" target="_blank">${subject}</a>` : subject}</td>
           <td>${campaignAnalyticsData[emailId][0].data.to.join(',')}</td>
           <td>${sent ? dateToRelativeSpan(sent.created_at).outerHTML : ''}</td>
           <td>${delivered ? dateToRelativeSpan(delivered.created_at).outerHTML : ''}</td>

--- a/blocks/site-details/renderCampaignsOverview.js
+++ b/blocks/site-details/renderCampaignsOverview.js
@@ -17,6 +17,7 @@ import { renderTable } from './renderSitePages.js';
 import { alertDialog, confirmDialog, createDialog } from '../../scripts/dialogs.js';
 import { readQueryParams, removeQueryParams } from '../../libs/queryParams/queryParams.js';
 import { showErrorToast, showToast } from '../../scripts/toast.js';
+import { createRedirectUrl } from '../../scripts/utils.js';
 
 export default async function renderCampaignsOverview({ container, nav, renderOptions, pushHistory, replaceHistory, onHistoryPopArray }) {
   const { projectDetails, user, token, siteSlug, pathname } = renderOptions;
@@ -40,7 +41,7 @@ export default async function renderCampaignsOverview({ container, nav, renderOp
   const emailDocuments = indexData.data.filter(({ path }) => path.startsWith('/emails/'));
 
   nav.innerHTML = `
-    <a href="/redirect?url=${projectDetails.authoringGuideUrl}" id="guides-button"
+    <a href="${createRedirectUrl(projectDetails.authoringGuideUrl)}" id="guides-button"
     title="Open the Guide for the Mail" class="button action secondary guides" target="_blank">Guides</a>
     <button id="delete-campaign" title="Delete the Campaign" class="button secondary delete-campaign action destructive" >Delete</button>
     <button id="add-email" title="Add Email" class="button secondary add-email action" >Add Email</button>

--- a/blocks/site-details/renderSettingsUtils.js
+++ b/blocks/site-details/renderSettingsUtils.js
@@ -1,6 +1,7 @@
 import { completeChecklistItem, OOPS, parseFragment, SCRIPT_API, slugifyFilename } from '../../scripts/scripts.js';
 import { alertDialog, confirmDialog, createDialog } from '../../scripts/dialogs.js';
 import { showToast } from '../../scripts/toast.js';
+import { createRedirectUrl } from '../../scripts/utils.js';
 
 const protectedBlocks = {
   header: true,
@@ -44,7 +45,7 @@ export function manageGoogleCalendarLink(calendarId, nav, onlyRemove = false) {
   nav.insertAdjacentHTML(
     'afterbegin',
     `<a class="button action secondary google-calendar-link" target="_blank" id="google-calendar"
-    href="/redirect?url=https://calendar.google.com/calendar/render?cid=${calendarId}">Google Calendar</a>`,
+    href="${createRedirectUrl(`https://calendar.google.com/calendar/render?cid=${calendarId}`)}">Google Calendar</a>`,
   );
 }
 
@@ -75,7 +76,7 @@ export function addIconDialogSetup({
     <div>
       <h3>${titleText}</h3>
       <form id="${formId}">
-        <p>${isFavicon ? 'Don\'t have an .ico file yet? You can convert your image to a .ico file <a href="/redirect?url=https://www.icoconverter.com/" target="_blank">here</a>.' : 'Upload a new SVG icon.'}</p>
+        <p>${isFavicon ? `Don't have an .ico file yet? You can convert your image to a .ico file <a href="${createRedirectUrl('https://www.icoconverter.com/')}" target="_blank">here</a>.` : 'Upload a new SVG icon.'}</p>
         <label>
           <span>File *</span>
           <input type="file" accept="${fileAccept}" required/>
@@ -373,7 +374,9 @@ function addBlockDialogSetup({ projectDetails, authHeaders, itemList, nav }) {
           const message = `Block "${select.value}" added.`;
           if (addRequestData.calendarId) {
             const calendarLink = parseFragment(`
-            <a class="button action primary" target="_blank" href="/redirect?url=https://calendar.google.com/calendar/render?cid=${addRequestData.calendarId}">Google Calendar</a>
+            <a class="button action primary" target="_blank" href="${createRedirectUrl(
+              `https://calendar.google.com/calendar/render?cid=${addRequestData.calendarId}`,
+            )}">Google Calendar</a>
           `);
 
             manageGoogleCalendarLink(addRequestData.calendarId, nav);

--- a/blocks/site-details/renderSiteOverview.js
+++ b/blocks/site-details/renderSiteOverview.js
@@ -3,6 +3,7 @@ import renderSkeleton from '../../scripts/skeletons.js';
 import { alertDialog, createDialog } from '../../scripts/dialogs.js';
 import renderCheckList from './renderCheckList.js';
 import { showToast } from '../../scripts/toast.js';
+import { createRedirectUrl } from '../../scripts/utils.js';
 
 export default async function renderSiteOverview({ container, nav, renderOptions, historyArray }) {
   const { projectDetails, user, token } = renderOptions;
@@ -12,7 +13,7 @@ export default async function renderSiteOverview({ container, nav, renderOptions
   // MARK: Extension tests
   const oldSidekickIds = ['ccfggkjabjahcjoljmgmklhpaccedipo', 'olciodlegapfmemadcjicljalmfmlehb', 'ahahnfffoakmmahloojpkmlkjjffnial'];
   const newSidekickId = 'igkmdomcgoebiipaifhmpfjhbjccggml';
-  const newSidekickLink = '/redirect?url=https://chromewebstore.google.com/detail/aem-sidekick/igkmdomcgoebiipaifhmpfjhbjccggml';
+  const newSidekickLink = createRedirectUrl('https://chromewebstore.google.com/detail/aem-sidekick/igkmdomcgoebiipaifhmpfjhbjccggml');
   async function checkExtension(id) {
     return fetch(`chrome-extension://${id}/lib/polyfills.min.js`)
       .then(() => true)
@@ -28,8 +29,8 @@ export default async function renderSiteOverview({ container, nav, renderOptions
   /* eslint-disable */
   nav.innerHTML = `
     <a href="${newSidekickLink}" id="install-sidekick-button" title="Install the Chrome Plugin Sidekick" class="button action secondary sidekick" target="_blank" data-sidekick-installed="${newSidekickInstalled}">Install Sidekick</a>
-    <a href="/redirect?url=${projectDetails.authoringGuideUrl}" id="guides-button" title="Open the Guide for the Template" class="button action secondary guides" target="_blank">Guides</a>
-    <a href="/redirect?url=${projectDetails.driveUrl}${!projectDetails.darkAlleyProject ? `?authuser=${user.email}` : ''}" id="edit-button" title="Edit your Content" class="button action secondary edit" target="_blank">Edit</a>
+    <a href="${createRedirectUrl(projectDetails.authoringGuideUrl)}" id="guides-button" title="Open the Guide for the Template" class="button action secondary guides" target="_blank">Guides</a>
+    <a href="${createRedirectUrl(`${projectDetails.driveUrl}${!projectDetails.darkAlleyProject ? `?authuser=${user.email}` : ''}`)}" id="edit-button" title="Edit your Content" class="button action secondary edit" target="_blank">Edit</a>
   `;
 
   // Warn user they are using deprecated sidekick version

--- a/blocks/site-details/renderSitePages.js
+++ b/blocks/site-details/renderSitePages.js
@@ -2,6 +2,7 @@ import { daProjectRepo, dateToRelativeSpan, EMAIL_WORKER_API, OOPS, parseFragmen
 import renderSkeleton from '../../scripts/skeletons.js';
 import { alertDialog, confirmDialog, createDialog } from '../../scripts/dialogs.js';
 import { showErrorToast, showToast } from '../../scripts/toast.js';
+import { createRedirectUrl } from '../../scripts/utils.js';
 
 export function renderTable({ table, tableData, type, projectDetails, token, isDrafts = false }) {
   const isEmail = type === 'emails';
@@ -36,9 +37,9 @@ export function renderTable({ table, tableData, type, projectDetails, token, isD
         <td>
           <div id="email-open-edit" class="button-container">
             <a class="button action secondary edit" href="/email/${projectDetails.projectSlug}${item.path}" target="_blank">Edit</a>
-            <a class="button action secondary open" href="/redirect?url=${EMAIL_WORKER_API}/preview?contentUrl=${
-              projectDetails.customPreviewUrl
-            }${item.path}" target="_blank">Open</a>
+            <a class="button action secondary open" href="${createRedirectUrl(
+              `${EMAIL_WORKER_API}/preview?contentUrl=${projectDetails.customPreviewUrl}${item.path}`,
+            )}" target="_blank">Open</a>
             ${isDeletable ? '<button class="button action secondary delete-email destructive">Delete</button>' : ''}
           </div>
         </td>
@@ -98,7 +99,7 @@ export function renderTable({ table, tableData, type, projectDetails, token, isD
       <td class="status"><div class="skeleton" style="width: 120px; height: 30px;"></div></td>
       <td>
         <div class="button-container">
-            <a class="button action secondary edit" href="/redirect?url=${projectDetails.darkAlleyProject ? `https://da.live/edit#/${daProjectRepo}/${projectDetails.projectSlug}${item.path.endsWith('/') ? `${item.path}index` : item.path}` : `https://docs.google.com/document/d/${item.id}/edit`}" target="_blank">Edit</a>
+            <a class="button action secondary edit" href="${createRedirectUrl(projectDetails.darkAlleyProject ? `https://da.live/edit#/${daProjectRepo}/${projectDetails.projectSlug}${item.path.endsWith('/') ? `${item.path}index` : item.path}` : `https://docs.google.com/document/d/${item.id}/edit`)}" target="_blank">Edit</a>
             <button class="button action secondary delete-page destructive">Delete</button>
         </div>
       </td>
@@ -111,13 +112,15 @@ export function renderTable({ table, tableData, type, projectDetails, token, isD
           tableRow.querySelector('.status').innerHTML = `<div class="badge ${variant}">${status}</div>`;
 
           const container = tableRow.querySelector('.button-container');
-          const previewButton = `<a class="button action secondary preview" href="/redirect?url=${projectDetails.customPreviewUrl}${item.path}" target="_blank">Preview</a>`;
+          const previewButton = `<a class="button action secondary preview" href="${createRedirectUrl(
+            `${projectDetails.customPreviewUrl}${item.path}`,
+          )}" target="_blank">Preview</a>`;
           if (status === 'Published') {
             container.insertAdjacentHTML(
               'afterbegin',
               `
               ${previewButton}
-              ${!item.path.startsWith('/drafts/') ? `<a class="button action secondary live" href="/redirect?url=${projectDetails.customLiveUrl}${item.path}" target="_blank">Live</a>` : ''}
+              ${!item.path.startsWith('/drafts/') ? `<a class="button action secondary live" href="${createRedirectUrl(`${projectDetails.customLiveUrl}${item.path}`)}" target="_blank">Live</a>` : ''}
             `,
             );
           } else if (status === 'Previewed') {
@@ -240,11 +243,11 @@ function addPageDialogSetup({ projectDetails, token, user }) {
       let editHref;
 
       if (projectDetails.darkAlleyProject) {
-        draftsHref = `/redirect?url=https://da.live/#${responseData.daPath}`;
-        editHref = `/redirect?url=https://da.live/edit#${responseData.daPath}/${responseData.daNewPageSlug}`;
+        draftsHref = createRedirectUrl(`https://da.live/#${responseData.daPath}`);
+        editHref = createRedirectUrl(`https://da.live/edit#${responseData.daPath}/${responseData.daNewPageSlug}`);
       } else {
-        draftsHref = `/redirect?url=https://drive.google.com/drive/folders/${responseData.folderId}?authuser=${user.email}`;
-        editHref = `/redirect?url=https://docs.google.com/document/d/${responseData.newPageId}/edit`;
+        draftsHref = createRedirectUrl(`https://drive.google.com/drive/folders/${responseData.folderId}?authuser=${user.email}`);
+        editHref = createRedirectUrl(`https://docs.google.com/document/d/${responseData.newPageId}/edit`);
       }
 
       const draftsLink = parseFragment(`
@@ -275,7 +278,9 @@ function addPageDialogSetup({ projectDetails, token, user }) {
             <td>Just now</td>
             <td class="status"><div class="badge orange">Previewed</div></td>
             <td class="button-container">
-                <a class="button action secondary preview" href="/redirect?url=${projectDetails.customPreviewUrl}/drafts/${responseData.pageSlug}" target="_blank">Preview</a>
+                <a class="button action secondary preview" href="${createRedirectUrl(
+                  `${projectDetails.customPreviewUrl}/drafts/${responseData.pageSlug}`,
+                )}" target="_blank">Preview</a>
                 <a class="button action secondary edit" href="${editHref}" target="_blank">Edit</a>
                 <button class="button action secondary delete-page destructive">Delete</button>
             </td>
@@ -296,7 +301,7 @@ export default async function renderSitePages({ container, nav, renderOptions })
 
   /* eslint-disable */
   nav.innerHTML = `
-    <a href="/redirect?url=${projectDetails.authoringGuideUrl}" id="guides-button" title="Open the Guide for the Template" class="button action secondary guides" target="_blank">Guides</a>
+    <a href="${createRedirectUrl(projectDetails.authoringGuideUrl)}" id="guides-button" title="Open the Guide for the Template" class="button action secondary guides" target="_blank">Guides</a>
     <button class="button secondary action add-page" id="add-page-button" title="Add a new Page">Add Page</button>
   `;
   nav.querySelector('#add-page-button').onclick = () => {

--- a/blocks/site-details/renderSiteSEO.js
+++ b/blocks/site-details/renderSiteSEO.js
@@ -3,7 +3,7 @@ import renderSkeleton from '../../scripts/skeletons.js';
 import { alertDialog, createDialog } from '../../scripts/dialogs.js';
 import paginator from '../../libs/pagination/pagination.js';
 import { readQueryParams } from '../../libs/queryParams/queryParams.js';
-import { cacheFetch } from '../../scripts/utils.js';
+import { cacheFetch, createRedirectUrl } from '../../scripts/utils.js';
 
 const filters = [/\/nav$/i, /\/footer$/i, /\/search$/i, /\/unsubscribe$/i, /^\/drafts\//i, /^\/tools\//i, /^\/emails\//i, /^\/\.helix\//i];
 
@@ -73,7 +73,7 @@ export default async function renderSiteSEO({ container, nav, renderOptions }) {
     `
     <button id="open-sitemap" class="button secondary action sitemap">Open sitemap</button>
     <button id="edit-robots" class="button secondary action robots">Edit robots</button>
-    ${projectDetails.darkAlleyProject ? `<a id="edit-bulk-metadata" href="/redirect?url=https://da.live/edit#/${daProjectRepo}/${siteSlug}/metadata" target="_blank" class="button secondary action">Edit Bulk Metadata</a>` : '<button id="edit-bulk-metadata" class="button secondary action bulk-metadata">Edit Bulk Metadata</button>'}
+    ${projectDetails.darkAlleyProject ? `<a id="edit-bulk-metadata" href="${createRedirectUrl(`https://da.live/edit#/${daProjectRepo}/${siteSlug}/metadata`)}" target="_blank" class="button secondary action">Edit Bulk Metadata</a>` : '<button id="edit-bulk-metadata" class="button secondary action bulk-metadata">Edit Bulk Metadata</button>'}
   `,
   );
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -26,16 +26,34 @@ export const projectRepo = 'headwire-self-service';
 export const daProjectRepo = 'da-self-service';
 
 if (window.location.hostname === 'localhost') {
+  function getRedirectLink(urlStr) {
+    const searchParams = new URLSearchParams(urlStr.replace(/^.*?\?/i, ''));
+    const paramObj = {};
+    for (const [key, value] of searchParams) {
+      paramObj[key] = value;
+    }
+    if (searchParams.size > 1)
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Redirect path had more params in addition to "url", this is probably unintentional and ment to be part of the "url" param. Make sure you encode the url!\nPath: ${urlStr}`,
+        paramObj,
+      );
+    const redirectTo = new URL(searchParams.get('url'));
+    searchParams.delete('url');
+    redirectTo.search = searchParams.toString();
+    return redirectTo.toString();
+  }
+
   document.addEventListener('mousedown', (event) => {
     if (event.target.matches('a[href^="/redirect?url="]')) {
-      event.target.setAttribute('href', event.target.getAttribute('href').replace('/redirect?url=', ''));
+      event.target.setAttribute('href', getRedirectLink(event.target.getAttribute('href')));
     }
   });
 
   const oldOpen = window.open;
   window.open = (...args) => {
     if (typeof args[0] === 'string' && args[0].startsWith('/redirect?url=')) {
-      args[0] = args[0].replace('/redirect?url=', '');
+      args[0] = getRedirectLink(args[0]);
     }
     return oldOpen(...args);
   };

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -28,19 +28,29 @@ export const daProjectRepo = 'da-self-service';
 if (window.location.hostname === 'localhost') {
   function getRedirectLink(urlStr) {
     const searchParams = new URLSearchParams(urlStr.replace(/^.*?\?/i, ''));
-    const paramObj = {};
-    for (const [key, value] of searchParams) {
-      paramObj[key] = value;
-    }
-    if (searchParams.size > 1)
+
+    // notify about wrongly setup queryparams
+    if (searchParams.size > 1) {
+      const paramObj = {};
+      for (const [key, value] of searchParams) {
+        paramObj[key] = value;
+      }
       // eslint-disable-next-line no-console
       console.warn(
         `Redirect path had more params in addition to "url", this is probably unintentional and ment to be part of the "url" param. Make sure you encode the url!\nPath: ${urlStr}`,
         paramObj,
       );
+    }
+
     const redirectTo = new URL(searchParams.get('url'));
     searchParams.delete('url');
-    redirectTo.search = searchParams.toString();
+    // append wrongly setup queryparams
+    const combinedParams = new URLSearchParams(redirectTo.searchParams);
+    for (const [key, value] of searchParams) {
+      if (!combinedParams.get(key)) combinedParams.set(key, value);
+    }
+
+    redirectTo.search = combinedParams.toString();
     return redirectTo.toString();
   }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -12,7 +12,7 @@ import {
   loadCSS,
   fetchPlaceholders,
 } from './aem.js';
-import { confirmUnsavedChanges, createRedirectUrl } from './utils.js';
+import { confirmUnsavedChanges, createRedirectUrl, getRedirectLink } from './utils.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 const range = document.createRange();
@@ -26,34 +26,6 @@ export const projectRepo = 'headwire-self-service';
 export const daProjectRepo = 'da-self-service';
 
 if (window.location.hostname === 'localhost') {
-  function getRedirectLink(urlStr) {
-    const searchParams = new URLSearchParams(urlStr.replace(/^.*?\?/i, ''));
-
-    // notify about wrongly setup queryparams
-    if (searchParams.size > 1) {
-      const paramObj = {};
-      for (const [key, value] of searchParams) {
-        paramObj[key] = value;
-      }
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Redirect path had more params in addition to "url", this is probably unintentional and ment to be part of the "url" param. Make sure you encode the url!\nPath: ${urlStr}`,
-        paramObj,
-      );
-    }
-
-    const redirectTo = new URL(searchParams.get('url'));
-    searchParams.delete('url');
-    // append wrongly setup queryparams
-    const combinedParams = new URLSearchParams(redirectTo.searchParams);
-    for (const [key, value] of searchParams) {
-      if (!combinedParams.get(key)) combinedParams.set(key, value);
-    }
-
-    redirectTo.search = combinedParams.toString();
-    return redirectTo.toString();
-  }
-
   document.addEventListener('mousedown', (event) => {
     if (event.target.matches('a[href^="/redirect?url="]')) {
       event.target.setAttribute('href', getRedirectLink(event.target.getAttribute('href')));

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -12,7 +12,7 @@ import {
   loadCSS,
   fetchPlaceholders,
 } from './aem.js';
-import { confirmUnsavedChanges } from './utils.js';
+import { confirmUnsavedChanges, createRedirectUrl } from './utils.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 const range = document.createRange();
@@ -419,7 +419,9 @@ export function createTabs({ block, breadcrumbs, tabs, renderOptions, defaultTab
 
   const defaultNavItems = block.querySelector('.tabs-default-nav-items');
   if (renderOptions?.projectDetails?.customLiveUrl) {
-    const openLink = parseFragment(`<a id="open-button" class="button action primary" href="/redirect?url=${renderOptions.projectDetails.customLiveUrl}" target="_blank">Open</a>`);
+    const openLink = parseFragment(
+      `<a id="open-button" class="button action primary" href="${createRedirectUrl(renderOptions.projectDetails.customLiveUrl)}" target="_blank">Open</a>`,
+    );
     openLink.onclick = () => window?.zaraz?.track('click site open');
     defaultNavItems.append(openLink);
   }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -165,3 +165,7 @@ export const escapeHTML = (str) => {
 
   return temp.innerHTML;
 };
+
+export const createRedirectUrl = (url) => {
+  return `/redirect?url=${encodeURIComponent(url)}`;
+};

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -169,3 +169,31 @@ export const escapeHTML = (str) => {
 export const createRedirectUrl = (url) => {
   return `/redirect?url=${encodeURIComponent(url)}`;
 };
+
+export const getRedirectLink = (urlStr) => {
+  const searchParams = new URLSearchParams(urlStr.replace(/^.*?\?/i, ''));
+
+  // notify about wrongly setup queryparams
+  if (searchParams.size > 1) {
+    const paramObj = {};
+    for (const [key, value] of searchParams) {
+      paramObj[key] = value;
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Redirect path had more params in addition to "url", this is probably unintentional and ment to be part of the "url" param. Make sure you encode the url!\nPath: ${urlStr}`,
+      paramObj,
+    );
+  }
+
+  const redirectTo = new URL(searchParams.get('url'));
+  searchParams.delete('url');
+  // append wrongly setup queryparams
+  const combinedParams = new URLSearchParams(redirectTo.searchParams);
+  for (const [key, value] of searchParams) {
+    if (!combinedParams.get(key)) combinedParams.set(key, value);
+  }
+
+  redirectTo.search = combinedParams.toString();
+  return redirectTo.toString();
+};


### PR DESCRIPTION
Fix #236 

Added handling for incorrect (non-encoded) `url` params on localhost with console.warn letting us know.
Added util function to easily make `/redirect?url=` paths.

(extra unencoded params will also be handled in the worker, but we should strive to do it the correct way anyway)
